### PR TITLE
Windows server core 2022 docker: initial set up targeting only Budget service

### DIFF
--- a/teamcityAgent/windows/windowsServerCore-2022/Dockerfile
+++ b/teamcityAgent/windows/windowsServerCore-2022/Dockerfile
@@ -1,0 +1,10 @@
+FROM jetbrains/teamcity-agent:2024.07.2-windowsservercore-2022
+
+USER ContainerAdministrator
+
+# Install Chocolatey and necessary tools
+RUN powershell -NoProfile -Command \
+    "Set-ExecutionPolicy Bypass -Scope Process -Force; \
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; \
+    iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1')); \
+    choco install sqlcmd sqlpackage visualstudio2022buildtools -y --no-progress"


### PR DESCRIPTION
The image has been pushed in this docker repository: `matrixsolutions/teamcity-agent-generic-v2` with the tag `windowsservercore-2022-budget`.
It has also been pushed to this `acr: matrixclarityqaacr.azurecr.io/matrixsolutions/teamcity-agent-generic-v2`with the tag `windowsservercore-2022-budget`.
A single Run command has been used to reduce layering.