### PR TITLE
Upgrade java version to 21 in the image for TeamCity generic Linux agent

### DIFF
--- a/teamcityAgent/linux/teamcity-agent-generic/Dockerfile_linuxupdated-java21
+++ b/teamcityAgent/linux/teamcity-agent-generic/Dockerfile_linuxupdated-java21
@@ -1,0 +1,20 @@
+FROM buildimagesacr.azurecr.io/matrixsolutions/teamcity-agent-generic:linuxupdated
+
+# Set environment variables for non-interactive installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set Java home and put on the front of the path
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+ENV PATH="$JAVA_HOME/bin:${PATH}"
+
+# Install Java 21
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-21-jdk
+
+# Set Java 21 as the default Java
+RUN update-alternatives --install "/usr/bin/java" "java" "$JAVA_HOME/bin/java" 20000 \
+    && update-alternatives --install "/usr/bin/javac" "javac" "$JAVA_HOME/bin/javac" 20000 \
+    && update-alternatives --set "java" "$JAVA_HOME/bin/java" \
+    && update-alternatives --set "javac" "$JAVA_HOME/bin/javac"
+
+# Remove Java 17
+RUN dpkg --purge --force-depends openjdk-17-jdk-headless openjdk-17-jre-headless || true


### PR DESCRIPTION
- The future version of TeamCity needs Java 21. We have updated it in this PR.
- We do not have the Docker file for `buildimagesacr.azurecr.io/matrixsolutions/teamcity-agent-generic:linuxupdated`.
At present, this is the only team city image we are using in team city.
- We are switching to use `buildimagesacr.azurecr.io/matrixsolutions/teamcity-agent-generic:linuxupdated-jave21` (the image of this PR) from `buildimagesacr.azurecr.io/matrixsolutions/teamcity-agent-generic:linuxupdated`.
- This image has been pushed to acr, [here](https://portal.azure.com/#view/Microsoft_Azure_ContainerRegistries/ImageMetadataBlade/registryId/%2Fsubscriptions%2F03c720b4-5e7e-49b2-9025-61c7501f5a37%2FresourceGroups%2Fmatrix-dev-ops%2Fproviders%2FMicrosoft.ContainerRegistry%2Fregistries%2Fbuildimagesacr/repositoryName/matrixsolutions%2Fteamcity-agent-generic/tag/linuxupdated-java21).